### PR TITLE
chore: #46 conectar menú principal con rutas de autenticación

### DIFF
--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -105,7 +105,7 @@
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>
                     Mi perfil
                 </a>
-                <form method="POST" action="/logout">
+                <form method="POST" action="{{ route('logout') }}">
                     @csrf
                     <button type="submit" x-on:mouseenter="$el.classList.add('bg-red-500/10','text-red-400')" x-on:mouseleave="$el.classList.remove('bg-red-500/10','text-red-400')" class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white/60 transition-all duration-200">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/></svg>
@@ -113,11 +113,11 @@
                     </button>
                 </form>
             @else
-                <a href="/login" x-on:mouseenter="$el.classList.add('bg-white/5','text-white')" x-on:mouseleave="$el.classList.remove('bg-white/5','text-white')" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white/60 transition-all duration-200">
+                <a href="{{ route('login') }}" x-on:mouseenter="$el.classList.add('bg-white/5','text-white')" x-on:mouseleave="$el.classList.remove('bg-white/5','text-white')" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white/60 transition-all duration-200">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/></svg>
                     Iniciar sesión
                 </a>
-                <a href="/register" x-on:mouseenter="$el.classList.add('bg-indigo-500/20','text-indigo-300')" x-on:mouseleave="$el.classList.remove('bg-indigo-500/20','text-indigo-300')" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-indigo-400 transition-all duration-200">
+                <a href="{{ route('register') }}" x-on:mouseenter="$el.classList.add('bg-indigo-500/20','text-indigo-300')" x-on:mouseleave="$el.classList.remove('bg-indigo-500/20','text-indigo-300')" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-indigo-400 transition-all duration-200">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/></svg>
                     Registrarse
                 </a>
@@ -212,8 +212,8 @@
         </div>
         @else
         <div class="flex flex-col gap-2 px-3">
-            <a href="/login" class="text-center py-2 rounded-lg text-sm text-white/60 border border-white/10 hover:border-white/30 hover:text-white transition-all duration-200">Iniciar sesión</a>
-            <a href="/register" class="text-center py-2 rounded-lg text-sm text-white bg-indigo-600 hover:bg-indigo-500 transition-all duration-200">Registrarse</a>
+            <a href="{{ route('login') }}" class="text-center py-2 rounded-lg text-sm text-white/60 border border-white/10 hover:border-white/30 hover:text-white transition-all duration-200">Iniciar sesión</a>
+            <a href="{{ route('register') }}" class="text-center py-2 rounded-lg text-sm text-white bg-indigo-600 hover:bg-indigo-500 transition-all duration-200">Registrarse</a>
         </div>
         @endauth
     </aside>


### PR DESCRIPTION
## ¿Qué se hizo?
- Reemplazadas rutas hardcodeadas /login, /register y /logout
- Ahora usan route('login'), route('register') y route('logout')
- Cambios aplicados en sidebar escritorio y sidebar móvil

## Closes
Closes #46