### PR TITLE
feat(vista): vista detalle de libro con animación fade-in

### DIFF
--- a/app/Http/Controllers/LibroController.php
+++ b/app/Http/Controllers/LibroController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Libro;
+
+class LibroController extends Controller
+{
+    public function show(Libro $libro)
+    {
+        $libro->load(['autor', 'categoria']);
+
+        return view('libros.detalle', compact('libro'));
+    }
+}

--- a/resources/views/libros/catalogo.blade.php
+++ b/resources/views/libros/catalogo.blade.php
@@ -18,45 +18,47 @@
         @else
             <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                 @foreach ($libros as $libro)
-                    <div x-data="{ hover: false }" x-on:mouseenter="hover = true" x-on:mouseleave="hover = false"
-                        :class="hover ? 'scale-105 shadow-2xl' : 'scale-100 shadow'"
-                        class="bg-[#1e2130] rounded-xl overflow-hidden transition-all duration-300 cursor-pointer">
-                        {{-- Portada --}}
-                        <div class="h-52 bg-[#2a2d3e] flex items-center justify-center overflow-hidden">
-                            @if ($libro->portada_url)
-                                <img src="{{ $libro->portada_url }}" alt="{{ $libro->titulo }}"
-                                    class="h-full w-full object-cover">
-                            @else
-                                <span class="text-6xl">📖</span>
-                            @endif
-                        </div>
-
-                        {{-- Info --}}
-                        <div class="p-4">
-                            {{-- Categoría --}}
-                            <span class="text-xs font-semibold px-2 py-0.5 rounded-full"
-                                style="background-color: {{ $libro->categoria->color }}30; color: {{ $libro->categoria->color }}">
-                                {{ $libro->categoria->nombre }}
-                            </span>
-
-                            <h3 class="font-bold text-white mt-2 line-clamp-2">{{ $libro->titulo }}</h3>
-                            <p class="text-sm text-gray-400 mt-1">{{ $libro->autor->nombre }}</p>
-
-                            @if ($libro->anio_publicacion)
-                                <p class="text-xs text-gray-500 mt-1">{{ $libro->anio_publicacion }}</p>
-                            @endif
-
-                            {{-- Disponibilidad --}}
-                            <div class="mt-3">
-                                @if ($libro->estaDisponible())
-                                    <span class="text-xs text-green-400">✓ Disponible
-                                        ({{ $libro->copias_disponibles }})</span>
+                    <a href="{{ route('libros.show', $libro) }}" class="block">
+                        <div x-data="{ hover: false }" x-on:mouseenter="hover = true" x-on:mouseleave="hover = false"
+                            :class="hover ? 'scale-105 shadow-2xl' : 'scale-100 shadow'"
+                            class="bg-[#1e2130] rounded-xl overflow-hidden transition-all duration-300 cursor-pointer">
+                            {{-- Portada --}}
+                            <div class="h-52 bg-[#2a2d3e] flex items-center justify-center overflow-hidden">
+                                @if ($libro->portada_url)
+                                    <img src="{{ $libro->portada_url }}" alt="{{ $libro->titulo }}"
+                                        class="h-full w-full object-cover">
                                 @else
-                                    <span class="text-xs text-red-400">✗ No disponible</span>
+                                    <span class="text-6xl">📖</span>
                                 @endif
                             </div>
+
+                            {{-- Info --}}
+                            <div class="p-4">
+                                {{-- Categoría --}}
+                                <span class="text-xs font-semibold px-2 py-0.5 rounded-full"
+                                    style="background-color: {{ $libro->categoria->color }}30; color: {{ $libro->categoria->color }}">
+                                    {{ $libro->categoria->nombre }}
+                                </span>
+
+                                <h3 class="font-bold text-white mt-2 line-clamp-2">{{ $libro->titulo }}</h3>
+                                <p class="text-sm text-gray-400 mt-1">{{ $libro->autor->nombre }}</p>
+
+                                @if ($libro->anio_publicacion)
+                                    <p class="text-xs text-gray-500 mt-1">{{ $libro->anio_publicacion }}</p>
+                                @endif
+
+                                {{-- Disponibilidad --}}
+                                <div class="mt-3">
+                                    @if ($libro->estaDisponible())
+                                        <span class="text-xs text-green-400">✓ Disponible
+                                            ({{ $libro->copias_disponibles }})
+                                        </span>
+                                    @else
+                                        <span class="text-xs text-red-400">✗ No disponible</span>
+                                    @endif
+                                </div>
+                            </div>
                         </div>
-                    </div>
                 @endforeach
             </div>
 

--- a/resources/views/libros/detalle.blade.php
+++ b/resources/views/libros/detalle.blade.php
@@ -1,0 +1,82 @@
+@extends('layouts.app')
+
+@section('content')
+    <div x-data="{ visible: false }" x-init="setTimeout(() => visible = true, 50)" x-show="visible" x-transition:enter="transition ease-out duration-500"
+        x-transition:enter-start="opacity-0 translate-y-4" x-transition:enter-end="opacity-100 translate-y-0"
+        class="max-w-4xl mx-auto px-4 py-8">
+        {{-- Botón volver --}}
+        <a href="{{ route('catalogo') }}"
+            class="inline-flex items-center gap-2 text-sm text-gray-400 hover:text-white transition mb-6">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+            Volver al catálogo
+        </a>
+
+        <div class="bg-[#1e2130] rounded-2xl overflow-hidden shadow-xl flex flex-col md:flex-row gap-0">
+
+            {{-- Portada --}}
+            <div class="md:w-64 flex-shrink-0 bg-[#2a2d3e] flex items-center justify-center min-h-64">
+                @if ($libro->portada_url)
+                    <img src="{{ $libro->portada_url }}" alt="{{ $libro->titulo }}" class="w-full h-full object-cover">
+                @else
+                    <span class="text-8xl">📖</span>
+                @endif
+            </div>
+
+            {{-- Información --}}
+            <div class="flex-1 p-8">
+
+                {{-- Categoría --}}
+                <span class="text-xs font-semibold px-3 py-1 rounded-full"
+                    style="background-color: {{ $libro->categoria->color }}30; color: {{ $libro->categoria->color }}">
+                    {{ $libro->categoria->nombre }}
+                </span>
+
+                {{-- Título --}}
+                <h1 class="text-3xl font-bold text-white mt-3">{{ $libro->titulo }}</h1>
+
+                {{-- Autor --}}
+                <p class="text-lg text-gray-400 mt-1">{{ $libro->autor->nombre }}</p>
+
+                {{-- Año --}}
+                @if ($libro->anio_publicacion)
+                    <p class="text-sm text-gray-500 mt-1">{{ $libro->anio_publicacion }}</p>
+                @endif
+
+                {{-- Disponibilidad --}}
+                <div class="mt-4">
+                    @if ($libro->estaDisponible())
+                        <span
+                            class="inline-flex items-center gap-2 text-sm text-green-400 bg-green-400/10 px-3 py-1 rounded-full">
+                            ✓ Disponible — {{ $libro->copias_disponibles }}
+                            {{ $libro->copias_disponibles === 1 ? 'copia' : 'copias' }}
+                        </span>
+                    @else
+                        <span
+                            class="inline-flex items-center gap-2 text-sm text-red-400 bg-red-400/10 px-3 py-1 rounded-full">
+                            ✗ No disponible
+                        </span>
+                    @endif
+                </div>
+
+                {{-- Descripción --}}
+                @if ($libro->descripcion)
+                    <div class="mt-6">
+                        <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-2">Descripción</h2>
+                        <p class="text-gray-300 leading-relaxed">{{ $libro->descripcion }}</p>
+                    </div>
+                @endif
+
+                {{-- Info del autor --}}
+                @if ($libro->autor->biografia)
+                    <div class="mt-6 border-t border-white/5 pt-6">
+                        <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-2">Sobre el autor</h2>
+                        <p class="text-gray-400 text-sm leading-relaxed">{{ $libro->autor->biografia }}</p>
+                    </div>
+                @endif
+
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\FavoritoController;
 use App\Http\Controllers\OpenLibraryController;
 use App\Http\Controllers\CatalogoController;
+use App\Http\Controllers\LibroController;
 
 Route::get('/open-library', function () {
     return view('libros.buscar', [
@@ -45,4 +46,5 @@ Route::get('/catalogo', [CatalogoController::class, 'index'])->name('catalogo');
 Route::post('/forgot-password', function () {
     return back()->with('status', 'Te enviamos el enlace a tu correo.');
 })->name('password.email');
-})->name('password.request');
+
+Route::get('/libros/{libro}', [LibroController::class, 'show'])->name('libros.show');

--- a/tests/Feature/LibroDetalleTest.php
+++ b/tests/Feature/LibroDetalleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Libro;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LibroDetalleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_detalle_libro_carga_correctamente(): void
+    {
+        $libro = Libro::factory()->create(['titulo' => 'El Principito']);
+
+        $respuesta = $this->get(route('libros.show', $libro));
+
+        $respuesta->assertStatus(200);
+        $respuesta->assertViewIs('libros.detalle');
+        $respuesta->assertSee('El Principito');
+    }
+
+    public function test_detalle_libro_devuelve_404_si_no_existe(): void
+    {
+        $respuesta = $this->get('/libros/9999');
+
+        $respuesta->assertStatus(404);
+    }
+}


### PR DESCRIPTION
Descripción:                            
  ## ¿Qué se hizo?
  - `LibroController` con método `show()` usando route model binding                                                                   - Vista `libros/detalle.blade.php` con animación fade-in al cargar (Alpine.js x-transition)
  - Muestra portada, título, autor, categoría, año, disponibilidad, descripción y biografía del autor                                
  - Placeholder 📖 para libros sin portada
  - Tarjetas del catálogo ahora enlazan a la vista detalle de cada libro
  - 2 tests de feature — todos passing

  ## ¿Cómo probarlo?
  1. Correr `php artisan migrate --seed`
  2. Ir a `http://localhost:8000/catalogo`
  3. Hacer click en cualquier tarjeta
  4. Verificar que carga el detalle con animación fade-in
  5. Ir a `/libros/9999` y verificar que devuelve 404

  ## Requisitos del maestro cubiertos
  - ✅ Animación de entrada con Alpine.js x-transition (fade-in)
  - ✅ Route model binding (Laravel best practice)
  - ✅ Eager loading con `load()` — sin N+1 queries
  - ✅ Tests: 2 passing

  Closes #68