### PR TITLE
test(tests): tests unitarios y de feature para modelos y controladores

### DIFF
--- a/database/factories/PrestamoFactory.php
+++ b/database/factories/PrestamoFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Libro;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PrestamoFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'libro_id' => Libro::factory(),
+            'fecha_prestamo' => Carbon::today(),
+            'fecha_devolucion_esperada' => Carbon::today()->addDays(14),
+            'fecha_devolucion_real' => null,
+            'estado' => 'activo',
+        ];
+    }
+}

--- a/database/migrations/2026_03_10_000003_create_libros_table.php
+++ b/database/migrations/2026_03_10_000003_create_libros_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->string('portada_url')->nullable();
             $table->integer('anio_publicacion')->nullable();
             $table->integer('copias_disponibles')->default(1);
-            $table->foreignId('autor_id')->constrained('autores')->cascadeOnDelete();
+            $table->foreignId('autor_id')->nullable()->constrained('autores')->nullOnDelete();
             $table->foreignId('categoria_id')->constrained('categorias')->cascadeOnDelete();
             $table->timestamps();
         });

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,10 @@ Route::get('/', function () {
 Route::middleware('auth')->group(function () {
     Route::get('/favoritos', [FavoritoController::class, 'index'])->name('favoritos');
     Route::post('/favoritos/{libro}/toggle', [FavoritoController::class, 'toggle'])->name('favoritos.toggle');
+    Route::post('/logout', function () {
+        auth()->logout();
+        return redirect('/');
+    })->name('logout');
 });
 
 Route::get('/login', function () {

--- a/tests/Feature/FavoritoControllerTest.php
+++ b/tests/Feature/FavoritoControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Libro;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FavoritoControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_toggle_agrega_favorito(): void
+    {
+        $usuario = User::factory()->create();
+        $libro   = Libro::factory()->create();
+
+        $respuesta = $this->actingAs($usuario)
+            ->postJson(route('favoritos.toggle', $libro));
+
+        $respuesta->assertStatus(200);
+        $respuesta->assertJson(['esFavorito' => true]);
+        $this->assertDatabaseHas('favoritos', [
+            'user_id'  => $usuario->id,
+            'libro_id' => $libro->id,
+        ]);
+    }
+
+    public function test_toggle_quita_favorito_si_ya_existe(): void
+    {
+        $usuario = User::factory()->create();
+        $libro   = Libro::factory()->create();
+
+        // Agregar primero
+        $this->actingAs($usuario)->postJson(route('favoritos.toggle', $libro));
+
+        // Quitar
+        $respuesta = $this->actingAs($usuario)
+            ->postJson(route('favoritos.toggle', $libro));
+
+        $respuesta->assertStatus(200);
+        $respuesta->assertJson(['esFavorito' => false]);
+        $this->assertDatabaseMissing('favoritos', [
+            'user_id'  => $usuario->id,
+            'libro_id' => $libro->id,
+        ]);
+    }
+
+    public function test_favoritos_requiere_autenticacion(): void
+    {
+        $libro = Libro::factory()->create();
+
+        $respuesta = $this->postJson(route('favoritos.toggle', $libro));
+
+        $respuesta->assertStatus(401);
+    }
+
+    public function test_index_muestra_favoritos_del_usuario(): void
+    {
+        $usuario = User::factory()->create();
+        $libro   = Libro::factory()->create();
+
+        $this->actingAs($usuario)->postJson(route('favoritos.toggle', $libro));
+
+        $respuesta = $this->actingAs($usuario)->get(route('favoritos'));
+
+        $respuesta->assertStatus(200);
+    }
+}

--- a/tests/Feature/OpenLibraryControllerTest.php
+++ b/tests/Feature/OpenLibraryControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Categoria;
+use App\Models\Libro;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class OpenLibraryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_pagina_buscar_carga_sin_termino(): void
+    {
+        $respuesta = $this->get(route('open-library.index'));
+
+        $respuesta->assertStatus(200);
+        $respuesta->assertViewIs('libros.buscar');
+    }
+
+    public function test_buscar_retorna_resultados(): void
+    {
+        Categoria::factory()->create();
+
+        Http::fake([
+            'openlibrary.org/search.json*' => Http::response([
+                'docs' => [
+                    [
+                        'title'              => 'Harry Potter',
+                        'author_name'        => ['J.K. Rowling'],
+                        'isbn'               => ['9780439708180'],
+                        'first_publish_year' => 1997,
+                        'cover_i'            => 12345,
+                        'key'                => '/works/OL82563W',
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $respuesta = $this->get(route('open-library.buscar') . '?termino=harry+potter');
+
+        $respuesta->assertStatus(200);
+        $respuesta->assertViewIs('libros.buscar');
+        $respuesta->assertViewHas('resultados');
+    }
+
+    public function test_buscar_requiere_termino(): void
+    {
+        $respuesta = $this->get(route('open-library.buscar'));
+
+        $respuesta->assertRedirect();
+    }
+
+    public function test_importar_libro_despacha_job(): void
+    {
+        $categoria = Categoria::factory()->create();
+
+        $respuesta = $this->post(route('open-library.importar'), [
+            'olid'               => 'OL82563W',
+            'categoria_id'       => $categoria->id,
+            'copias_disponibles' => 2,
+        ]);
+
+        $respuesta->assertRedirect();
+        $respuesta->assertSessionHas('exito');
+    }
+
+    public function test_importar_requiere_categoria_valida(): void
+    {
+        $respuesta = $this->post(route('open-library.importar'), [
+            'olid'         => 'OL82563W',
+            'categoria_id' => 9999,
+        ]);
+
+        $respuesta->assertRedirect();
+        $respuesta->assertSessionHasErrors('categoria_id');
+    }
+}

--- a/tests/Feature/OpenLibraryServiceTest.php
+++ b/tests/Feature/OpenLibraryServiceTest.php
@@ -50,6 +50,75 @@ class OpenLibraryServiceTest extends TestCase
         $this->assertEmpty($resultados);
     }
 
+    public function test_buscar_por_isbn_retorna_datos_del_libro(): void
+    {
+        Http::fake([
+            'openlibrary.org/api/books*' => Http::response([
+                'ISBN:9780060883287' => [
+                    'details' => [
+                        'title'        => 'Cien años de soledad',
+                        'authors'      => [['name' => 'Gabriel García Márquez']],
+                        'publish_date' => '1967',
+                        'covers'       => [12345],
+                        'works'        => [['key' => '/works/OL123W']],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $servicio  = new OpenLibraryService();
+        $resultado = $servicio->buscarPorIsbn('9780060883287');
+
+        $this->assertNotNull($resultado);
+        $this->assertEquals('Cien años de soledad', $resultado['titulo']);
+    }
+
+    public function test_buscar_por_isbn_retorna_null_si_no_encuentra(): void
+    {
+        Http::fake([
+            'openlibrary.org/api/books*' => Http::response([], 200),
+        ]);
+
+        $servicio  = new OpenLibraryService();
+        $resultado = $servicio->buscarPorIsbn('0000000000000');
+
+        $this->assertNull($resultado);
+    }
+
+    public function test_importar_libro_retorna_null_si_api_falla(): void
+    {
+        Http::fake([
+            'openlibrary.org/works/OL999W.json' => Http::response([], 500),
+        ]);
+
+        $categoria = Categoria::factory()->create();
+        $servicio  = new OpenLibraryService();
+
+        $libro = $servicio->importarLibro('OL999W', $categoria->id);
+
+        $this->assertNull($libro);
+    }
+
+    public function test_importar_libro_sin_autor_key(): void
+    {
+        Http::fake([
+            'openlibrary.org/works/OL456W.json' => Http::response([
+                'title'       => 'Libro sin autor',
+                'description' => 'Descripcion.',
+                'covers'      => [],
+                'authors'     => [],
+            ], 200),
+        ]);
+
+        $categoria = Categoria::factory()->create();
+        $servicio  = new OpenLibraryService();
+
+        $libro = $servicio->importarLibro('OL456W', $categoria->id);
+
+        $this->assertNotNull($libro);
+        $this->assertEquals('Libro sin autor', $libro->titulo);
+    }
+
     public function test_importar_libro_crea_autor_y_libro_en_bd(): void
     {
         Http::fake([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,9 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
 }

--- a/tests/Unit/AutorTest.php
+++ b/tests/Unit/AutorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Autor;
+use App\Models\Libro;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AutorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_total_libros_retorna_cantidad_correcta(): void
+    {
+        $autor = Autor::factory()->create();
+        Libro::factory()->count(3)->create(['autor_id' => $autor->id]);
+
+        $this->assertEquals(3, $autor->totalLibros());
+    }
+
+    public function test_total_libros_retorna_cero_sin_libros(): void
+    {
+        $autor = Autor::factory()->create();
+
+        $this->assertEquals(0, $autor->totalLibros());
+    }
+
+    public function test_autor_tiene_muchos_libros(): void
+    {
+        $autor = Autor::factory()->create();
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $autor->libros);
+    }
+}

--- a/tests/Unit/CategoriaTest.php
+++ b/tests/Unit/CategoriaTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Categoria;
+use App\Models\Libro;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CategoriaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_total_libros_retorna_cantidad_correcta(): void
+    {
+        $categoria = Categoria::factory()->create();
+        Libro::factory()->count(4)->create(['categoria_id' => $categoria->id]);
+
+        $this->assertEquals(4, $categoria->totalLibros());
+    }
+
+    public function test_total_libros_retorna_cero_sin_libros(): void
+    {
+        $categoria = Categoria::factory()->create();
+
+        $this->assertEquals(0, $categoria->totalLibros());
+    }
+
+    public function test_categoria_tiene_muchos_libros(): void
+    {
+        $categoria = Categoria::factory()->create();
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $categoria->libros);
+    }
+}

--- a/tests/Unit/FavoritoTest.php
+++ b/tests/Unit/FavoritoTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Favorito;
+use App\Models\Libro;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FavoritoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_favorito_pertenece_a_un_usuario(): void
+    {
+        $usuario = User::factory()->create();
+        $libro   = Libro::factory()->create();
+
+        $favorito = Favorito::create([
+            'user_id'  => $usuario->id,
+            'libro_id' => $libro->id,
+        ]);
+
+        $this->assertInstanceOf(User::class, $favorito->usuario);
+    }
+
+    public function test_favorito_pertenece_a_un_libro(): void
+    {
+        $usuario = User::factory()->create();
+        $libro   = Libro::factory()->create();
+
+        $favorito = Favorito::create([
+            'user_id'  => $usuario->id,
+            'libro_id' => $libro->id,
+        ]);
+
+        $this->assertInstanceOf(Libro::class, $favorito->libro);
+    }
+}

--- a/tests/Unit/LibroTest.php
+++ b/tests/Unit/LibroTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Autor;
+use App\Models\Categoria;
+use App\Models\Libro;
+use App\Models\Prestamo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LibroTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_esta_disponible_retorna_true_cuando_hay_copias(): void
+    {
+        $libro = Libro::factory()->create(['copias_disponibles' => 3]);
+
+        $this->assertTrue($libro->estaDisponible());
+    }
+
+    public function test_esta_disponible_retorna_false_cuando_no_hay_copias(): void
+    {
+        $libro = Libro::factory()->create(['copias_disponibles' => 0]);
+
+        $this->assertFalse($libro->estaDisponible());
+    }
+
+    public function test_scope_buscar_filtra_por_titulo(): void
+    {
+        Libro::factory()->create(['titulo' => 'Cien Anos de Soledad']);
+        Libro::factory()->create(['titulo' => 'El Principito']);
+
+        $resultados = Libro::buscar('Cien')->get();
+
+        $this->assertCount(1, $resultados);
+        $this->assertEquals('Cien Anos de Soledad', $resultados->first()->titulo);
+    }
+
+    public function test_scope_buscar_filtra_por_nombre_de_autor(): void
+    {
+        $autor = Autor::factory()->create(['nombre' => 'Gabriel Garcia Marquez']);
+        Libro::factory()->create(['autor_id' => $autor->id]);
+        Libro::factory()->create();
+
+        $resultados = Libro::buscar('Gabriel')->get();
+
+        $this->assertCount(1, $resultados);
+    }
+
+    public function test_scope_por_categoria_filtra_correctamente(): void
+    {
+        $categoria = Categoria::factory()->create();
+        Libro::factory()->count(2)->create(['categoria_id' => $categoria->id]);
+        Libro::factory()->create();
+
+        $resultados = Libro::porCategoria($categoria->id)->get();
+
+        $this->assertCount(2, $resultados);
+    }
+
+    public function test_libro_pertenece_a_un_autor(): void
+    {
+        $libro = Libro::factory()->create();
+
+        $this->assertInstanceOf(Autor::class, $libro->autor);
+    }
+
+    public function test_libro_pertenece_a_una_categoria(): void
+    {
+        $libro = Libro::factory()->create();
+
+        $this->assertInstanceOf(Categoria::class, $libro->categoria);
+    }
+
+    public function test_libro_tiene_muchos_prestamos(): void
+    {
+        $libro = Libro::factory()->create();
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $libro->prestamos);
+    }
+}

--- a/tests/Unit/PrestamoTest.php
+++ b/tests/Unit/PrestamoTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Libro;
+use App\Models\Prestamo;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PrestamoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_esta_vencido_retorna_true_cuando_paso_la_fecha(): void
+    {
+        $prestamo = Prestamo::factory()->create([
+            'estado' => 'activo',
+            'fecha_devolucion_esperada' => Carbon::today()->subDays(1),
+        ]);
+
+        $this->assertTrue($prestamo->estaVencido());
+    }
+
+    public function test_esta_vencido_retorna_false_cuando_no_ha_vencido(): void
+    {
+        $prestamo = Prestamo::factory()->create([
+            'estado' => 'activo',
+            'fecha_devolucion_esperada' => Carbon::today()->addDays(5),
+        ]);
+
+        $this->assertFalse($prestamo->estaVencido());
+    }
+
+    public function test_dias_restantes_retorna_valor_correcto(): void
+    {
+        $prestamo = Prestamo::factory()->create([
+            'fecha_devolucion_esperada' => Carbon::today()->addDays(7),
+        ]);
+
+        $this->assertEquals(7, $prestamo->diasRestantes());
+    }
+
+    public function test_crear_prestamo_guarda_en_bd(): void
+    {
+        $user = User::factory()->create();
+        $libro = Libro::factory()->create();
+
+        $prestamo = Prestamo::crearPrestamo($user->id, $libro->id, 14);
+
+        $this->assertDatabaseHas('prestamos', [
+            'user_id' => $user->id,
+            'libro_id' => $libro->id,
+            'estado' => 'activo',
+        ]);
+        $this->assertEquals(14, $prestamo->diasRestantes());
+    }
+
+    public function test_prestamo_pertenece_a_un_libro(): void
+    {
+        $prestamo = Prestamo::factory()->create();
+
+        $this->assertInstanceOf(Libro::class, $prestamo->libro);
+    }
+
+    public function test_prestamo_pertenece_a_un_usuario(): void
+    {
+        $prestamo = Prestamo::factory()->create();
+
+        $this->assertInstanceOf(User::class, $prestamo->user);
+    }
+}

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Libro;
+use App\Models\User;
+use App\Models\Favorito;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_es_favorito_retorna_true_si_libro_es_favorito(): void
+    {
+        $usuario = User::factory()->create();
+        $libro   = Libro::factory()->create();
+
+        Favorito::create([
+            'user_id'  => $usuario->id,
+            'libro_id' => $libro->id,
+        ]);
+
+        $this->assertTrue($usuario->esFavorito($libro->id));
+    }
+
+    public function test_es_favorito_retorna_false_si_libro_no_es_favorito(): void
+    {
+        $usuario = User::factory()->create();
+        $libro   = Libro::factory()->create();
+
+        $this->assertFalse($usuario->esFavorito($libro->id));
+    }
+
+    public function test_usuario_tiene_muchos_favoritos(): void
+    {
+        $usuario = User::factory()->create();
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $usuario->favoritos);
+    }
+}


### PR DESCRIPTION
## ¿Qué se hizo?
  Se agregaron tests unitarios para todos los modelos del sistema y tests de feature para los controladores principales.

  ### Tests unitarios (`tests/Unit/`)
  - `AutorTest` — totalLibros(), relación hasMany libros
  - `CategoriaTest` — totalLibros(), relación hasMany libros
  - `LibroTest` — estaDisponible(), scopeBuscar(), scopePorCategoria(), relaciones
  - `PrestamoTest` — estaVencido(), diasRestantes(), crearPrestamo(), relaciones
  - `FavoritoTest` — relaciones belongsTo usuario y libro
  - `UserTest` — esFavorito(), relación hasMany favoritos

  ### Tests de feature (`tests/Feature/`)
  - `OpenLibraryServiceTest` — buscarLibros(), buscarPorIsbn(), importarLibro() con Http::fake()
  - `OpenLibraryControllerTest` — rutas GET/POST de búsqueda e importación
  - `FavoritoControllerTest` — toggle agregar/quitar, autenticación, vista index

  ### Correcciones incluidas
  - `autor_id` ahora es nullable en la migración de libros (libros sin autor conocido)
  - Ruta `logout` agregada a `web.php`
  - `withoutVite()` en `TestCase` base para evitar error de manifest en tests

  ## ¿Cómo probarlo?
  ```bash
  php artisan test tests/Unit tests/Feature/OpenLibraryServiceTest.php tests/Feature/OpenLibraryControllerTest.php tests/Feature/FavoritoControllerTest.php
  Resultado esperado: 42 tests, 62 assertions, 0 failures