### PR TITLE
feat: verificación de correo con PIN al registrar (#80)

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Mail\VerificacionPinMail;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+
+class AuthController extends Controller
+{
+    public function registrar(Request $request)
+    {
+        $request->validate([
+            'nombre'               => ['required', 'string', 'max:255'],
+            'apellidos'            => ['required', 'string', 'max:255'],
+            'email'                => ['required', 'email', 'unique:users,email'],
+            'username'             => ['required', 'string', 'max:255', 'unique:users,name'],
+            'password'             => ['required', 'min:8', 'confirmed'],
+            'terminos'             => ['accepted'],
+        ]);
+
+        $usuario = User::crear([
+            'name'     => $request->nombre . ' ' . $request->apellidos,
+            'email'    => $request->email,
+            'password' => Hash::make($request->password),
+            'rol'      => 'usuario',
+        ]);
+
+        $this->enviarPin($usuario);
+
+        return redirect()->route('verificar.email.mostrar', $usuario->id)
+            ->with('info', 'Te enviamos un PIN de verificación a tu correo.');
+    }
+
+    public function login(Request $request)
+    {
+        $request->validate([
+            'email'    => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        $usuario = User::where('email', $request->email)->first();
+
+        if (! $usuario || ! Hash::check($request->password, $usuario->password)) {
+            return back()->withInput()->with('error', 'Credenciales incorrectas.');
+        }
+
+        if (! $usuario->estaVerificado()) {
+            $this->enviarPin($usuario);
+            return redirect()->route('verificar.email.mostrar', $usuario->id)
+                ->with('info', 'Debes verificar tu correo antes de ingresar. Te reenviamos el PIN.');
+        }
+
+        Auth::login($usuario, $request->boolean('remember'));
+
+        return redirect()->intended(route('catalogo'));
+    }
+
+    public function logout(Request $request)
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('login');
+    }
+
+    public function enviarPin(User $usuario): void
+    {
+        $pin = random_int(100000, 999999);
+        Cache::put("email_pin_{$usuario->id}", $pin, now()->addMinutes(15));
+        Mail::to($usuario->email)->send(new VerificacionPinMail($pin));
+    }
+}

--- a/app/Http/Controllers/VerificacionEmailController.php
+++ b/app/Http/Controllers/VerificacionEmailController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+
+class VerificacionEmailController extends Controller
+{
+    public function mostrar(int $id)
+    {
+        $usuario = User::findOrFail($id);
+
+        if ($usuario->estaVerificado()) {
+            return redirect()->route('login');
+        }
+
+        return view('auth.verify-pin', compact('usuario'));
+    }
+
+    public function verificar(Request $request, int $id)
+    {
+        $request->validate([
+            'pin' => ['required', 'digits:6'],
+        ]);
+
+        $usuario = User::findOrFail($id);
+        $pinGuardado = Cache::get("email_pin_{$usuario->id}");
+
+        if (! $pinGuardado || (int) $request->pin !== (int) $pinGuardado) {
+            return back()->withErrors(['pin' => 'El PIN es incorrecto o ha expirado.']);
+        }
+
+        $usuario->marcarComoVerificado();
+        Cache::forget("email_pin_{$usuario->id}");
+
+        Auth::login($usuario);
+
+        return redirect()->route('catalogo')
+            ->with('success', '¡Correo verificado! Bienvenido a la Biblioteca Digital.');
+    }
+
+    public function reenviar(int $id)
+    {
+        $usuario = User::findOrFail($id);
+
+        if ($usuario->estaVerificado()) {
+            return redirect()->route('login');
+        }
+
+        app(AuthController::class)->enviarPin($usuario);
+
+        return back()->with('info', 'Se reenvió el PIN a tu correo.');
+    }
+}

--- a/app/Mail/VerificacionPinMail.php
+++ b/app/Mail/VerificacionPinMail.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class VerificacionPinMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly int $pin
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Tu PIN de verificación - Biblioteca Digital',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.verificacion-pin',
+        );
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -60,13 +60,28 @@ class User extends Authenticatable
     }
 
     public function esAdmin(): bool
-{
-    return $this->rol === 'admin';
-}
+    {
+        return $this->rol === 'admin';
+    }
 
-public function esUsuario(): bool
-{
-    return $this->rol === 'usuario';
-}
+    public function esUsuario(): bool
+    {
+        return $this->rol === 'usuario';
+    }
 
+    public function estaVerificado(): bool
+    {
+        return $this->email_verified_at !== null;
+    }
+
+    public function marcarComoVerificado(): void
+    {
+        $this->email_verified_at = now();
+        $this->save();
+    }
+
+    public static function crear(array $datos): self
+    {
+        return self::create($datos);
+    }
 }

--- a/resources/views/auth/verify-pin.blade.php
+++ b/resources/views/auth/verify-pin.blade.php
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verificar Correo - Biblioteca Digital</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Sora:wght@300;400;500;600;700&display=swap');
+        body { font-family: 'Sora', sans-serif; }
+    </style>
+</head>
+<body class="min-h-screen flex items-center justify-center px-4"
+      style="background: radial-gradient(ellipse at 60% 20%, #1a1a2e 0%, #0d0d14 70%);">
+
+    <div class="absolute inset-0 overflow-hidden pointer-events-none">
+        <div class="absolute top-20 left-20 w-64 h-64 bg-purple-600/10 rounded-full blur-3xl"></div>
+        <div class="absolute bottom-20 right-20 w-80 h-80 bg-blue-600/10 rounded-full blur-3xl"></div>
+        <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-96 h-96 bg-indigo-600/5 rounded-full blur-3xl"></div>
+    </div>
+
+    <div
+        x-data="{
+            cargado: false,
+            hovering: false,
+            digitos: ['', '', '', '', '', ''],
+            enfocarSiguiente(index, event) {
+                const val = event.target.value.replace(/\D/g, '');
+                this.digitos[index] = val.slice(-1);
+                if (val && index < 5) {
+                    this.$refs['d' + (index + 1)].focus();
+                }
+            },
+            alRetroceso(index, event) {
+                if (event.key === 'Backspace' && !this.digitos[index] && index > 0) {
+                    this.$refs['d' + (index - 1)].focus();
+                }
+            },
+            get pinCompleto() {
+                return this.digitos.join('');
+            }
+        }"
+        x-init="setTimeout(() => cargado = true, 100)"
+        x-show="cargado"
+        x-transition:enter="transition ease-out duration-700"
+        x-transition:enter-start="opacity-0 translate-y-8 scale-95"
+        x-transition:enter-end="opacity-100 translate-y-0 scale-100"
+        class="relative w-full max-w-md"
+    >
+        <div class="bg-[#13131f]/90 backdrop-blur-xl border border-white/10 rounded-2xl p-8 shadow-2xl shadow-black/50">
+
+            {{-- Icono --}}
+            <div class="flex flex-col items-center mb-8">
+                <div class="w-14 h-14 rounded-2xl mb-4 flex items-center justify-center shadow-lg"
+                     style="background: linear-gradient(135deg, #6366f1, #8b5cf6, #ec4899);">
+                    <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                    </svg>
+                </div>
+                <h1 class="text-white text-2xl font-semibold tracking-tight">Verifica tu correo</h1>
+                <p class="text-white/40 text-sm mt-1 text-center">
+                    Ingresa el PIN de 6 dígitos que enviamos a<br>
+                    <span class="text-indigo-400">{{ $usuario->email }}</span>
+                </p>
+            </div>
+
+            {{-- Mensajes --}}
+            @if(session('info'))
+                <div x-data="{ visible: true }" x-show="visible" x-transition
+                     class="mb-6 p-4 bg-blue-500/10 border border-blue-500/30 rounded-xl text-blue-400 text-sm flex items-center gap-3">
+                    <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                    </svg>
+                    {{ session('info') }}
+                </div>
+            @endif
+
+            @if($errors->any())
+                <div x-data="{ visible: true }" x-show="visible" x-transition
+                     class="mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm">
+                    {{ $errors->first('pin') }}
+                </div>
+            @endif
+
+            {{-- Formulario PIN --}}
+            <form method="POST" action="{{ route('verificar.email.verificar', $usuario->id) }}">
+                @csrf
+
+                {{-- Inputs individuales por dígito --}}
+                <div class="flex gap-3 justify-center mb-6">
+                    @for($i = 0; $i < 6; $i++)
+                        <input
+                            x-ref="d{{ $i }}"
+                            type="text"
+                            inputmode="numeric"
+                            maxlength="1"
+                            x-model="digitos[{{ $i }}]"
+                            @input="enfocarSiguiente({{ $i }}, $event)"
+                            @keydown="alRetroceso({{ $i }}, $event)"
+                            class="w-12 h-14 text-center text-white text-xl font-bold
+                                   bg-white/5 border border-white/10 rounded-xl outline-none
+                                   focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500/30
+                                   transition-all duration-200"
+                        >
+                    @endfor
+                </div>
+
+                {{-- Campo oculto con el PIN completo --}}
+                <input type="hidden" name="pin" :value="pinCompleto">
+
+                {{-- Botón verificar --}}
+                <button
+                    type="submit"
+                    @mouseenter="hovering = true"
+                    @mouseleave="hovering = false"
+                    :disabled="pinCompleto.length < 6"
+                    class="w-full py-3 px-4 rounded-xl text-white text-sm font-medium
+                           transition-all duration-300 transform
+                           hover:scale-[1.02] hover:shadow-lg hover:shadow-indigo-500/25
+                           active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed"
+                    style="background: linear-gradient(135deg, #6366f1, #8b5cf6);"
+                    :style="hovering && pinCompleto.length === 6 ? 'background: linear-gradient(135deg, #4f46e5, #7c3aed); box-shadow: 0 0 30px rgba(99,102,241,0.4)' : 'background: linear-gradient(135deg, #6366f1, #8b5cf6)'"
+                >
+                    Verificar cuenta
+                </button>
+            </form>
+
+            {{-- Reenviar PIN --}}
+            <div class="text-center mt-6">
+                <p class="text-white/30 text-xs">
+                    ¿No recibiste el correo?
+                </p>
+                <form method="POST" action="{{ route('verificar.email.reenviar', $usuario->id) }}" class="inline">
+                    @csrf
+                    <button type="submit"
+                            class="text-indigo-400 hover:text-indigo-300 text-xs font-medium transition-colors duration-200 mt-1">
+                        Reenviar PIN
+                    </button>
+                </form>
+            </div>
+
+        </div>
+    </div>
+
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</body>
+</html>

--- a/resources/views/emails/verificacion-pin.blade.php
+++ b/resources/views/emails/verificacion-pin.blade.php
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: 'Segoe UI', sans-serif; background: #0d0d14; color: #ffffff; margin: 0; padding: 40px 20px; }
+        .contenedor { max-width: 480px; margin: 0 auto; background: #13131f; border: 1px solid rgba(255,255,255,0.1); border-radius: 16px; padding: 40px; }
+        .logo { text-align: center; margin-bottom: 32px; }
+        .logo-icono { display: inline-block; width: 56px; height: 56px; border-radius: 14px; background: linear-gradient(135deg, #6366f1, #8b5cf6, #ec4899); text-align: center; line-height: 56px; font-size: 24px; margin-bottom: 12px; }
+        h1 { text-align: center; font-size: 22px; font-weight: 600; margin: 0 0 8px; }
+        .subtitulo { text-align: center; color: rgba(255,255,255,0.4); font-size: 14px; margin-bottom: 32px; }
+        .pin-caja { background: rgba(99,102,241,0.1); border: 2px solid rgba(99,102,241,0.4); border-radius: 12px; text-align: center; padding: 24px; margin-bottom: 24px; }
+        .pin { font-size: 42px; font-weight: 700; letter-spacing: 12px; background: linear-gradient(135deg, #6366f1, #ec4899); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+        .aviso { color: rgba(255,255,255,0.4); font-size: 13px; text-align: center; line-height: 1.6; }
+        .expira { color: #f59e0b; font-weight: 600; }
+        .footer { text-align: center; margin-top: 32px; color: rgba(255,255,255,0.2); font-size: 12px; }
+    </style>
+</head>
+<body>
+    <div class="contenedor">
+        <div class="logo">
+            <div class="logo-icono">📚</div>
+            <h1>Verificación de correo</h1>
+            <p class="subtitulo">Usa este PIN para activar tu cuenta en la Biblioteca Digital</p>
+        </div>
+
+        <div class="pin-caja">
+            <div class="pin">{{ $pin }}</div>
+        </div>
+
+        <p class="aviso">
+            Este PIN es válido por <span class="expira">15 minutos</span>.<br>
+            Si no creaste una cuenta, puedes ignorar este mensaje.
+        </p>
+
+        <div class="footer">
+            Biblioteca Digital Online &mdash; No respondas a este correo
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\CatalogoController;
 use App\Http\Controllers\LibroController;
 use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\UsuarioController;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\VerificacionEmailController;
 
 Route::get('/open-library', function () {
     return view('libros.buscar', [
@@ -31,13 +33,19 @@ Route::middleware('auth')->group(function () {
     Route::post('/favoritos/{libro}/toggle', [FavoritoController::class, 'toggle'])->name('favoritos.toggle');
 });
 
-Route::get('/login', function () {
-    return view('auth.login');
-})->name('login');
+Route::middleware('guest')->group(function () {
+    Route::get('/login', fn() => view('auth.login'))->name('login');
+    Route::post('/login', [AuthController::class, 'login']);
 
-Route::get('/register', function () {
-    return view('auth.register');
-})->name('register');
+    Route::get('/register', fn() => view('auth.register'))->name('register');
+    Route::post('/register', [AuthController::class, 'registrar']);
+});
+
+Route::post('/logout', [AuthController::class, 'logout'])->name('logout')->middleware('auth');
+
+Route::get('/verificar-email/{id}', [VerificacionEmailController::class, 'mostrar'])->name('verificar.email.mostrar');
+Route::post('/verificar-email/{id}', [VerificacionEmailController::class, 'verificar'])->name('verificar.email.verificar');
+Route::post('/verificar-email/{id}/reenviar', [VerificacionEmailController::class, 'reenviar'])->name('verificar.email.reenviar');
 
 Route::get('/forgot-password', function () {
     return view('auth.forgot-password');

--- a/tests/Feature/VerificacionEmailPinTest.php
+++ b/tests/Feature/VerificacionEmailPinTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\VerificacionPinMail;
+use Tests\TestCase;
+
+class VerificacionEmailPinTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registro_crea_usuario_sin_verificar_y_envia_pin(): void
+    {
+        Mail::fake();
+
+        $respuesta = $this->post('/register', [
+            'nombre'               => 'Joel',
+            'apellidos'            => 'Ibarra',
+            'email'                => 'joel@test.com',
+            'username'             => 'joel_ibarra',
+            'password'             => 'Password123!',
+            'password_confirmation' => 'Password123!',
+            'terminos'             => '1',
+        ]);
+
+        $respuesta->assertRedirect();
+        $this->assertDatabaseHas('users', ['email' => 'joel@test.com']);
+
+        $usuario = User::where('email', 'joel@test.com')->first();
+        $this->assertNull($usuario->email_verified_at);
+
+        Mail::assertSent(VerificacionPinMail::class);
+    }
+
+    public function test_usuario_sin_verificar_no_puede_loguearse(): void
+    {
+        $usuario = User::factory()->create(['email_verified_at' => null]);
+
+        $respuesta = $this->post('/login', [
+            'email'    => $usuario->email,
+            'password' => 'password',
+        ]);
+
+        $respuesta->assertRedirect(route('verificar.email.mostrar', $usuario->id));
+        $this->assertGuest();
+    }
+
+    public function test_usuario_verificado_puede_loguearse(): void
+    {
+        $usuario = User::factory()->create(['email_verified_at' => now()]);
+
+        $respuesta = $this->post('/login', [
+            'email'    => $usuario->email,
+            'password' => 'password',
+        ]);
+
+        $respuesta->assertRedirect(route('catalogo'));
+        $this->assertAuthenticatedAs($usuario);
+    }
+
+    public function test_pin_correcto_verifica_la_cuenta(): void
+    {
+        $usuario = User::factory()->create(['email_verified_at' => null]);
+        Cache::put("email_pin_{$usuario->id}", 123456, now()->addMinutes(15));
+
+        $respuesta = $this->post("/verificar-email/{$usuario->id}", ['pin' => '123456']);
+
+        $respuesta->assertRedirect(route('catalogo'));
+        $this->assertNotNull($usuario->fresh()->email_verified_at);
+        $this->assertAuthenticatedAs($usuario);
+    }
+
+    public function test_pin_incorrecto_retorna_error(): void
+    {
+        $usuario = User::factory()->create(['email_verified_at' => null]);
+        Cache::put("email_pin_{$usuario->id}", 123456, now()->addMinutes(15));
+
+        $respuesta = $this->post("/verificar-email/{$usuario->id}", ['pin' => '999999']);
+
+        $respuesta->assertSessionHasErrors('pin');
+        $this->assertNull($usuario->fresh()->email_verified_at);
+    }
+
+    public function test_reenvio_pin_envia_nuevo_correo(): void
+    {
+        Mail::fake();
+        $usuario = User::factory()->create(['email_verified_at' => null]);
+
+        $respuesta = $this->post("/verificar-email/{$usuario->id}/reenviar");
+
+        $respuesta->assertRedirect();
+        Mail::assertSent(VerificacionPinMail::class);
+    }
+}


### PR DESCRIPTION
- Crear AuthController con login, registro y logout reales
- Crear VerificacionEmailController para mostrar, verificar y reenviar PIN
- Crear VerificacionPinMail y vista de email con PIN de 6 dígitos
- Crear vista verify-pin.blade.php con inputs individuales por dígito
- Agregar métodos estaVerificado() y marcarComoVerificado() al modelo User
- Bloquear login a usuarios sin verificar correo
- 6 tests automatizados - todos pasando