### PR TITLE
feat(#100): buscador con filtros dependientes categoría-autor en tiempo real

### DIFF
--- a/app/Livewire/BuscadorLibros.php
+++ b/app/Livewire/BuscadorLibros.php
@@ -2,6 +2,8 @@
 
 namespace App\Livewire;
 
+use App\Models\Autor;
+use App\Models\Categoria;
 use App\Models\Libro;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -11,8 +13,21 @@ class BuscadorLibros extends Component
     use WithPagination;
 
     public string $termino = '';
+    public string $categoriaId = '';
+    public string $autorId = '';
 
     public function updatingTermino(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingCategoriaId(): void
+    {
+        $this->autorId = '';
+        $this->resetPage();
+    }
+
+    public function updatingAutorId(): void
     {
         $this->resetPage();
     }
@@ -21,9 +36,18 @@ class BuscadorLibros extends Component
     {
         $libros = Libro::with(['autor', 'categoria'])
             ->when($this->termino, fn($q) => $q->buscar($this->termino))
+            ->when($this->categoriaId, fn($q) => $q->where('categoria_id', $this->categoriaId))
+            ->when($this->autorId, fn($q) => $q->where('autor_id', $this->autorId))
             ->orderBy('titulo')
             ->paginate(12);
 
-        return view('livewire.buscador-libros', compact('libros'));
+        $categorias = Categoria::orderBy('nombre')->get();
+
+        $autores = Autor::when(
+            $this->categoriaId,
+            fn($q) => $q->whereHas('libros', fn($q) => $q->where('categoria_id', $this->categoriaId))
+        )->orderBy('nombre')->get();
+
+        return view('livewire.buscador-libros', compact('libros', 'categorias', 'autores'));
     }
 }

--- a/resources/views/livewire/buscador-libros.blade.php
+++ b/resources/views/livewire/buscador-libros.blade.php
@@ -1,18 +1,53 @@
 <div>
     {{-- Campo de búsqueda --}}
-    <div class="relative mb-8">
+    <div class="relative mb-4">
         <svg class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" fill="none" stroke="currentColor"
-            viewBox="0 0 
-  24 24">
+            viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
         <input type="text" wire:model.live.debounce.300ms="termino" placeholder="Buscar por título o autor..."
-            class="w-full bg-[#1e2130] border border-white/10 rounded-xl pl-12 pr-4 py-3 text-white placeholder-gray-500
-  focus:outline-none focus:ring-2 focus:ring-indigo-500 transition">
+            class="w-full bg-[#1e2130] border border-white/10 rounded-xl pl-12 pr-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition">
         @if ($termino)
             <button wire:click="$set('termino', '')"
                 class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white transition">✕</button>
+        @endif
+    </div>
+
+    {{-- Filtros dependientes --}}
+    <div class="flex flex-col sm:flex-row gap-3 mb-8">
+        {{-- Combo categoría --}}
+        <div class="flex-1">
+            <select wire:model.live="categoriaId"
+                class="w-full bg-[#1e2130] border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 transition">
+                <option value="">Todas las categorías</option>
+                @foreach ($categorias as $categoria)
+                    <option value="{{ $categoria->id }}">{{ $categoria->nombre }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        {{-- Combo autor (dependiente de categoría) --}}
+        <div class="flex-1">
+            <select wire:model.live="autorId"
+                class="w-full bg-[#1e2130] border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 transition
+                    {{ $autores->isEmpty() ? 'opacity-50 cursor-not-allowed' : '' }}"
+                {{ $autores->isEmpty() ? 'disabled' : '' }}>
+                <option value="">
+                    {{ $categoriaId ? 'Todos los autores de esta categoría' : 'Todos los autores' }}
+                </option>
+                @foreach ($autores as $autor)
+                    <option value="{{ $autor->id }}">{{ $autor->nombre }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        {{-- Limpiar filtros --}}
+        @if ($categoriaId || $autorId)
+            <button wire:click="$set('categoriaId', ''); $set('autorId', '')"
+                class="px-4 py-3 bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white rounded-xl transition text-sm whitespace-nowrap">
+                Limpiar filtros
+            </button>
         @endif
     </div>
 


### PR DESCRIPTION
## ¿Qué se hizo?
  Se extendió el buscador dinámico de libros (Livewire) agregando filtros
  dependientes en tiempo real.

  ## Funcionalidad
  - Combo de categorías para filtrar libros
  - Combo de autores **dependiente**: al seleccionar una categoría, muestra
    solo los autores que tienen libros en esa categoría
  - Al limpiar la categoría, el combo de autores vuelve a mostrar todos
  - Botón "Limpiar filtros" cuando hay filtros activos
  - Los resultados combinan: término de búsqueda + categoría + autor
  - El debounce de 300ms sigue funcionando en el campo de texto

  ## Requisito del maestro que cubre
  Req. 13 — búsqueda con debounce + campo dependiente en tiempo real

  ## ¿Cómo probarlo?
  1. Ir a `/buscar`
  2. Seleccionar una categoría y verificar que el combo de autores se actualiza
  3. Seleccionar un autor y verificar que los resultados se filtran
  4. Combinar búsqueda por texto + categoría + autor