### PR TITLE
feat: #90 Perfil de usuario con foto

### DIFF
--- a/app/Http/Controllers/PerfilController.php
+++ b/app/Http/Controllers/PerfilController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PerfilController extends Controller
+{
+    public function index()
+    {
+        $usuario = auth()->user();
+        return view('perfil.index', compact('usuario'));
+    }
+
+    public function actualizar(Request $request)
+    {
+        $request->validate([
+            'name'  => 'required|string|max:255',
+            'foto'  => 'nullable|image|mimes:jpg,jpeg,png,webp|max:2048',
+        ]);
+
+        $usuario = auth()->user();
+        $usuario->name = $request->name;
+
+        if ($request->hasFile('foto')) {
+            // Eliminar foto anterior si existe
+            if ($usuario->foto) {
+                \Storage::disk('public')->delete($usuario->foto);
+            }
+
+            $ruta = $request->file('foto')->store('fotos', 'public');
+            $usuario->foto = $ruta;
+        }
+
+        $usuario->save();
+
+        return back()->with('success', 'Perfil actualizado correctamente.');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable
         'password',
         'rol',
         'activo',
+        'foto',
     ];
 
     /**

--- a/database/migrations/2026_03_15_144009_agregar_foto_a_users.php
+++ b/database/migrations/2026_03_15_144009_agregar_foto_a_users.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('foto')->nullable()->after('activo');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('foto');
+        });
+    }
+};

--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -133,12 +133,16 @@
             <span class="text-[10px] font-semibold tracking-widest text-white/30 uppercase px-3 mb-1">Cuenta</span>
             @auth
                 <div class="flex items-center gap-3 px-3 py-2 mb-1">
-                    <div class="w-8 h-8 rounded-full bg-indigo-500 flex items-center justify-center text-white text-xs font-bold">
-                        {{ strtoupper(substr(auth()->user()->name, 0, 1)) }}
-                    </div>
+                    @if(auth()->user()->foto)
+                        <img src="{{ asset('storage/' . auth()->user()->foto) }}" alt="Foto" class="w-8 h-8 rounded-full object-cover border border-indigo-500/50">
+                    @else
+                        <div class="w-8 h-8 rounded-full bg-indigo-500 flex items-center justify-center text-white text-xs font-bold">
+                            {{ strtoupper(substr(auth()->user()->name, 0, 1)) }}
+                        </div>
+                    @endif
                     <span class="text-sm text-white/80 truncate">{{ auth()->user()->name }}</span>
                 </div>
-                <a href="#" x-on:mouseenter="$el.classList.add('bg-white/5','text-white')" x-on:mouseleave="$el.classList.remove('bg-white/5','text-white')" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white/60 transition-all duration-200">
+                <a href="{{ route('perfil') }}" x-on:mouseenter="$el.classList.add('bg-white/5','text-white')" x-on:mouseleave="$el.classList.remove('bg-white/5','text-white')" class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white/60 transition-all duration-200">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>
                     Mi perfil
                 </a>
@@ -254,9 +258,13 @@
         <div class="flex flex-col gap-1">
             <span class="text-[10px] font-semibold tracking-widest text-white/30 uppercase px-3 mb-1">Cuenta</span>
             <div class="flex items-center gap-3 px-3 py-2">
-                <div class="w-8 h-8 rounded-full bg-indigo-500 flex items-center justify-center text-white text-xs font-bold">
-                    {{ strtoupper(substr(auth()->user()->name, 0, 1)) }}
-                </div>
+                @if(auth()->user()->foto)
+                    <img src="{{ asset('storage/' . auth()->user()->foto) }}" alt="Foto" class="w-8 h-8 rounded-full object-cover border border-indigo-500/50">
+                @else
+                    <div class="w-8 h-8 rounded-full bg-indigo-500 flex items-center justify-center text-white text-xs font-bold">
+                        {{ strtoupper(substr(auth()->user()->name, 0, 1)) }}
+                    </div>
+                @endif
                 <span class="text-sm text-white/80 truncate">{{ auth()->user()->name }}</span>
             </div>
             <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/perfil/index.blade.php
+++ b/resources/views/perfil/index.blade.php
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mi Perfil - Biblioteca Digital</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-[#13151f] text-white min-h-screen">
+
+    @include('components.navigation')
+
+    <main class="lg:ml-64 min-h-screen p-6 lg:p-10">
+
+        <div class="mb-8">
+            <h1 class="text-3xl font-bold text-white">Mi Perfil</h1>
+            <p class="text-white/50 mt-1">Actualiza tu información personal</p>
+        </div>
+
+        @if(session('success'))
+        <div
+            x-data="{ visible: true }"
+            x-show="visible"
+            x-init="setTimeout(() => visible = false, 3000)"
+            class="mb-6 px-4 py-3 bg-green-500/20 border border-green-500/30 rounded-xl text-green-400 text-sm"
+        >
+            {{ session('success') }}
+        </div>
+        @endif
+
+        @if($errors->any())
+        <div class="mb-6 px-4 py-3 bg-red-500/20 border border-red-500/30 rounded-xl text-red-400 text-sm">
+            @foreach($errors->all() as $error)
+                <p>{{ $error }}</p>
+            @endforeach
+        </div>
+        @endif
+
+        <div class="max-w-lg">
+            <form
+                method="POST"
+                action="{{ route('perfil.actualizar') }}"
+                enctype="multipart/form-data"
+                class="bg-[#1a1d2e] rounded-2xl p-8 border border-white/5"
+            >
+                @csrf
+
+                {{-- Foto de perfil --}}
+                <div class="flex flex-col items-center mb-8">
+                    <div class="relative">
+                        @if($usuario->foto)
+                            <img
+                                src="{{ asset('storage/' . $usuario->foto) }}"
+                                alt="Foto de perfil"
+                                class="w-24 h-24 rounded-full object-cover border-2 border-indigo-500/50"
+                                id="preview-foto"
+                            >
+                        @else
+                            <div
+                                class="w-24 h-24 rounded-full bg-indigo-600 flex items-center justify-center text-white text-3xl font-bold border-2 border-indigo-500/50"
+                                id="avatar-inicial"
+                            >
+                                {{ strtoupper(substr($usuario->name, 0, 1)) }}
+                            </div>
+                            <img
+                                src=""
+                                alt="Foto de perfil"
+                                class="w-24 h-24 rounded-full object-cover border-2 border-indigo-500/50 hidden"
+                                id="preview-foto"
+                            >
+                        @endif
+
+                        {{-- Botón de cambiar foto --}}
+                        <label
+                            for="foto"
+                            class="absolute bottom-0 right-0 w-8 h-8 bg-indigo-600 hover:bg-indigo-500 rounded-full flex items-center justify-center cursor-pointer transition-colors duration-200"
+                        >
+                            <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
+                            </svg>
+                        </label>
+                        <input
+                            type="file"
+                            name="foto"
+                            id="foto"
+                            accept="image/jpeg,image/png,image/webp"
+                            class="hidden"
+                            onchange="previewFoto(this)"
+                        >
+                    </div>
+                    <p class="text-white/30 text-xs mt-3">JPG, PNG o WEBP — máx. 2MB</p>
+                </div>
+
+                {{-- Nombre --}}
+                <div class="flex flex-col gap-2 mb-6">
+                    <label class="text-sm text-white/60">Nombre</label>
+                    <input
+                        type="text"
+                        name="name"
+                        value="{{ old('name', $usuario->name) }}"
+                        required
+                        class="bg-[#13151f] border border-white/10 rounded-xl px-4 py-3 text-sm text-white placeholder-white/20 focus:outline-none focus:border-indigo-500/50 transition-colors duration-200"
+                    >
+                </div>
+
+                {{-- Email (solo lectura) --}}
+                <div class="flex flex-col gap-2 mb-8">
+                    <label class="text-sm text-white/60">Correo electrónico</label>
+                    <input
+                        type="email"
+                        value="{{ $usuario->email }}"
+                        disabled
+                        class="bg-[#13151f] border border-white/5 rounded-xl px-4 py-3 text-sm text-white/30 cursor-not-allowed"
+                    >
+                    <p class="text-white/20 text-xs">El correo no se puede cambiar</p>
+                </div>
+
+                <button
+                    type="submit"
+                    class="w-full py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium transition-all duration-200"
+                >
+                    Guardar cambios
+                </button>
+
+            </form>
+        </div>
+
+    </main>
+
+    <script>
+        function previewFoto(input) {
+            if (input.files && input.files[0]) {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    const preview = document.getElementById('preview-foto');
+                    const inicial = document.getElementById('avatar-inicial');
+                    preview.src = e.target.result;
+                    preview.classList.remove('hidden');
+                    if (inicial) inicial.classList.add('hidden');
+                };
+                reader.readAsDataURL(input.files[0]);
+            }
+        }
+    </script>
+
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,3 +128,10 @@ Route::get('/login-super', function () {
     auth()->login($usuario);
     return redirect('/superadmin');
 });
+
+use App\Http\Controllers\PerfilController;
+
+Route::middleware('auth')->group(function () {
+    Route::get('/perfil', [PerfilController::class, 'index'])->name('perfil');
+    Route::post('/perfil', [PerfilController::class, 'actualizar'])->name('perfil.actualizar');
+});


### PR DESCRIPTION
## ¿Qué se hizo?
- Migración para agregar campo foto a la tabla users
- Controlador PerfilController con validación de imagen (jpg/png/webp, máx 2MB)
- Vista de perfil con subida de foto y preview en tiempo real
- Foto de perfil visible en el menú de navegación (escritorio y móvil)
- El correo electrónico es de solo lectura

## ¿Cómo probarlo?
1. Iniciar sesión
2. Ir a http://127.0.0.1:8000/perfil
3. Subir una foto y verificar que aparece en el menú
4. Cambiar el nombre y guardar

## Closes
Closes #90