### PR TITLE
test: agregar tests unitarios para #82, #83, #84 y fix OpenLibrary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+/coverage-report
+/playwright-report
+/test-results

--- a/tests/Feature/GraficaUsuariosTest.php
+++ b/tests/Feature/GraficaUsuariosTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GraficaUsuariosTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_grafica_requiere_autenticacion(): void
+    {
+        $respuesta = $this->get('/superadmin/grafica');
+        $respuesta->assertRedirect('/login');
+    }
+
+    public function test_usuario_normal_no_puede_ver_grafica(): void
+    {
+        $usuario = User::factory()->create(['rol' => 'usuario']);
+        $respuesta = $this->actingAs($usuario)->get('/superadmin/grafica');
+        $respuesta->assertStatus(403);
+    }
+
+    public function test_superadmin_puede_ver_grafica(): void
+    {
+        $superadmin = User::factory()->create(['rol' => 'superadmin']);
+        $respuesta = $this->actingAs($superadmin)->get('/superadmin/grafica');
+        $respuesta->assertStatus(200);
+    }
+
+    public function test_endpoint_stats_retorna_json(): void
+    {
+        $superadmin = User::factory()->create(['rol' => 'superadmin']);
+
+        $respuesta = $this->actingAs($superadmin)
+            ->get('/superadmin/stats/usuarios');
+
+        $respuesta->assertStatus(200);
+        $respuesta->assertJsonStructure([
+            'fechas',
+            'totales',
+        ]);
+    }
+
+    public function test_stats_retorna_datos_correctos(): void
+    {
+        $superadmin = User::factory()->create(['rol' => 'superadmin']);
+        User::factory()->count(3)->create();
+
+        $respuesta = $this->actingAs($superadmin)
+            ->get('/superadmin/stats/usuarios');
+
+        $respuesta->assertStatus(200);
+        $data = $respuesta->json();
+        $this->assertIsArray($data['fechas']);
+        $this->assertIsArray($data['totales']);
+    }
+}

--- a/tests/Feature/OpenLibraryControllerTest.php
+++ b/tests/Feature/OpenLibraryControllerTest.php
@@ -7,6 +7,7 @@ use App\Models\Libro;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
+use Illuminate\Support\Facades\Queue;
 
 class OpenLibraryControllerTest extends TestCase
 {
@@ -55,6 +56,9 @@ class OpenLibraryControllerTest extends TestCase
 
     public function test_importar_libro_despacha_job(): void
     {
+        Queue::fake();
+        Http::fake();
+
         $categoria = Categoria::factory()->create();
 
         $respuesta = $this->post(route('open-library.importar'), [

--- a/tests/Feature/PerfilControllerTest.php
+++ b/tests/Feature/PerfilControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PerfilControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_perfil_requiere_autenticacion(): void
+    {
+        $respuesta = $this->get('/perfil');
+        $respuesta->assertRedirect('/login');
+    }
+
+    public function test_perfil_carga_correctamente(): void
+    {
+        $usuario = User::factory()->create();
+        $respuesta = $this->actingAs($usuario)->get('/perfil');
+        $respuesta->assertStatus(200);
+    }
+
+    public function test_actualizar_nombre_correctamente(): void
+    {
+        $usuario = User::factory()->create(['name' => 'Nombre Viejo']);
+
+        $respuesta = $this->actingAs($usuario)->post('/perfil', [
+            'name' => 'Nombre Nuevo',
+        ]);
+
+        $respuesta->assertRedirect();
+        $this->assertDatabaseHas('users', ['name' => 'Nombre Nuevo']);
+    }
+
+    public function test_actualizar_requiere_nombre(): void
+    {
+        $usuario = User::factory()->create();
+
+        $respuesta = $this->actingAs($usuario)->post('/perfil', [
+            'name' => '',
+        ]);
+
+        $respuesta->assertSessionHasErrors('name');
+    }
+
+    public function test_subir_foto_de_perfil(): void
+    {
+        Storage::fake('public');
+        $usuario = User::factory()->create();
+
+        $foto = UploadedFile::fake()->image('foto.jpg', 100, 100);
+
+        $respuesta = $this->actingAs($usuario)->post('/perfil', [
+            'name' => $usuario->name,
+            'foto' => $foto,
+        ]);
+
+        $respuesta->assertRedirect();
+        $this->assertNotNull($usuario->fresh()->foto);
+    }
+
+    public function test_foto_invalida_es_rechazada(): void
+    {
+        $usuario = User::factory()->create();
+
+        $archivo = UploadedFile::fake()->create('documento.pdf', 100);
+
+        $respuesta = $this->actingAs($usuario)->post('/perfil', [
+            'name' => $usuario->name,
+            'foto' => $archivo,
+        ]);
+
+        $respuesta->assertSessionHasErrors('foto');
+    }
+}

--- a/tests/Feature/SuperAdminControllerTest.php
+++ b/tests/Feature/SuperAdminControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SuperAdminControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_panel_requiere_autenticacion(): void
+    {
+        $respuesta = $this->get('/superadmin');
+        $respuesta->assertRedirect('/login');
+    }
+
+    public function test_usuario_normal_no_puede_acceder(): void
+    {
+        $usuario = User::factory()->create(['rol' => 'usuario']);
+        $respuesta = $this->actingAs($usuario)->get('/superadmin');
+        $respuesta->assertStatus(403);
+    }
+
+    public function test_admin_no_puede_acceder(): void
+    {
+        $admin = User::factory()->create(['rol' => 'admin']);
+        $respuesta = $this->actingAs($admin)->get('/superadmin');
+        $respuesta->assertStatus(403);
+    }
+
+    public function test_superadmin_puede_acceder(): void
+    {
+        $superadmin = User::factory()->create(['rol' => 'superadmin']);
+        $respuesta = $this->actingAs($superadmin)->get('/superadmin');
+        $respuesta->assertStatus(200);
+    }
+
+    public function test_superadmin_puede_desactivar_usuario(): void
+    {
+        $superadmin = User::factory()->create(['rol' => 'superadmin']);
+        $usuario = User::factory()->create(['rol' => 'usuario', 'activo' => true]);
+
+        $respuesta = $this->actingAs($superadmin)
+            ->post("/superadmin/usuarios/{$usuario->id}/toggle-estado");
+
+        $respuesta->assertRedirect();
+        $this->assertFalse($usuario->fresh()->activo);
+    }
+
+    public function test_superadmin_puede_cambiar_rol(): void
+    {
+        $superadmin = User::factory()->create(['rol' => 'superadmin']);
+        $usuario = User::factory()->create(['rol' => 'usuario']);
+
+        $respuesta = $this->actingAs($superadmin)
+            ->post("/superadmin/usuarios/{$usuario->id}/cambiar-rol/admin");
+
+        $respuesta->assertRedirect();
+        $this->assertDatabaseHas('users', [
+            'id'  => $usuario->id,
+            'rol' => 'admin',
+        ]);
+    }
+
+    public function test_superadmin_no_puede_desactivarse_a_si_mismo(): void
+    {
+        $superadmin = User::factory()->create(['rol' => 'superadmin']);
+
+        $respuesta = $this->actingAs($superadmin)
+            ->post("/superadmin/usuarios/{$superadmin->id}/toggle-estado");
+
+        $respuesta->assertRedirect();
+        $respuesta->assertSessionHas('error');
+    }
+}


### PR DESCRIPTION
## ¿Qué se hizo?
- Agregados tests para PerfilController (#82): 6 tests
- Agregados tests para SuperAdminController (#83): 7 tests
- Agregados tests para GraficaUsuarios (#84): 5 tests
- Corregido test de OpenLibraryController (Http::fake + Queue::fake)

## Resultado
✅ 94/94 tests pasando (165 assertions)

## Comando de ejecución
php artisan test

## Archivos agregados
- tests/Feature/PerfilControllerTest.php
- tests/Feature/SuperAdminControllerTest.php
- tests/Feature/GraficaUsuariosTest.php

## Archivos modificados
- tests/Feature/OpenLibraryControllerTest.php